### PR TITLE
Solve code-stopping HGVS naming bug

### DIFF
--- a/bin/functions.py
+++ b/bin/functions.py
@@ -83,7 +83,7 @@ def add_hgvs_names(new_gvf):
     # for ins
     nt_ins_regex = "[a-z]\.[0-9\-_]+ins[A-Z]+"
     # for delins, eg. g.GCC10182_10184ACA
-    nt_delins_regex = "[a-z]\.[A-Z]{2,}[0-9\-_][A-Z]{2,}"
+    nt_delins_regex = "[a-z]\.[A-Z]{2,}[0-9\-_][A-Z]+" ##not quite right!
     
     #df.loc[mask, 'val'] = df.loc[mask, 'val'].apply(f)
     # add hgvs nt snp names
@@ -99,7 +99,7 @@ def add_hgvs_names(new_gvf):
     new_gvf.loc[nt_ins_mask, 'hgvs_nt'] = new_gvf['#seqid'] + ":" + new_gvf['nt_name']  
     # add hgvs nt delins: change to eg. g.123_129delinsAC
     nt_delins_mask = new_gvf['nt_name'].str.contains(nt_delins_regex, regex=True)
-    new_gvf.loc[nt_delins_mask, 'hgvs_nt'] = new_gvf['#seqid'] + ":" + "TBA!" #new_gvf['nt_name']  
+    #new_gvf.loc[nt_delins_mask, 'hgvs_nt'] = new_gvf['#seqid'] + ":" + "TBA!" #new_gvf['nt_name']  
 
     # define aa regex patterns
     aa_snp_regex = "[A-Z*][0-9\-]+[A-Z*]"
@@ -121,12 +121,12 @@ def add_hgvs_names(new_gvf):
     # add hgvs alias snps to rows with protein_id!=n/a
     alias_snp_mask = (new_gvf['alias'].str.contains(aa_snp_regex, regex=True)) & (new_gvf['protein_id']!='n/a') & (new_gvf['alias']!='n/a')
     new_gvf.loc[alias_snp_mask, 'hgvs_alias'] = \
-                new_gvf["protein_id"] + ":" + new_gvf.loc[alias_snp_mask, 'aa_name'].apply(
+                new_gvf["protein_id"] + ":" + new_gvf.loc[alias_snp_mask, 'alias'].apply(
                     convert_amino_acid_codes)
     # add hgvs alias names for non-snps
     alias_non_snp_mask = (new_gvf['alias'].str.contains(aa_other_regex, regex=True)) & (new_gvf['protein_id']!='n/a') & (new_gvf['alias']!='n/a')
     new_gvf.loc[alias_non_snp_mask, 'hgvs_alias'] = \
-                new_gvf["protein_id"] + ":" + new_gvf.loc[alias_non_snp_mask, 'aa_name'].apply(
+                new_gvf["protein_id"] + ":" + new_gvf.loc[alias_non_snp_mask, 'alias'].apply(
                     convert_amino_acid_codes)
                 
     return(new_gvf)

--- a/bin/functions.py
+++ b/bin/functions.py
@@ -44,10 +44,10 @@ def convert_amino_acid_codes(one_letter_mutation_name):
 
 def rewrite_nt_snps_as_hgvs(original_nt_name):
     ## NOTE: this function doesn't add the ref sequence; this must be done separately
-    original_nt_name = original_nt_name[2:] # remove "g."
+    print(original_nt_name)
     pos = "".join([i for i in original_nt_name if i.isdigit()])
     nts_list = [ch for ch in original_nt_name if ch.isupper()]
-    hgvs_name = "g." + pos + nts_list[0] + ">" + nts_list[1]
+    hgvs_name = "g." + pos + nts_list[0] + ">" + nts_list[1] ##may change "g." in future
 
     return(hgvs_name)
 
@@ -74,29 +74,59 @@ def add_hgvs_names(new_gvf):
     new_gvf['hgvs_alias'] = 'n/a'
     
     # fill in 'hgvs_nt'
-    # add hgvs nt snps for rows where type==snp
-    new_gvf.loc[(new_gvf['nt_name'].str.startswith("g.")) & (new_gvf['#type']=='snp'), 'hgvs_nt'] = new_gvf['#seqid'] + ":" + new_gvf['nt_name'].apply(rewrite_nt_snps_as_hgvs)
+    
+    # define nt regex patterns
+    # for SNPs, eg. g.C45T, g.C-45T
+    nt_snp_regex = "[a-z]\.[A-Z][0-9\-]+[A-Z]"
+    # for dels and dups, eg. g.254_259delTGGTTG, g.361delA
+    nt_del_dup_regex = "[a-z]\.[0-9\-_]+(del|dup)[A-Z]+"
+    # for ins
+    nt_ins_regex = "[a-z]\.[0-9\-_]+ins[A-Z]+"
+    
+    # add hgvs nt snp names
+    new_gvf.loc[new_gvf['nt_name'].str.contains(nt_snp_regex, regex=True), 
+                'hgvs_nt'] = new_gvf['#seqid'] + ":" + \
+                new_gvf['nt_name'].apply(rewrite_nt_snps_as_hgvs)
     # add hgvs nt dels and dups
-    new_gvf.loc[(new_gvf['nt_name'].str.startswith("g.")) & (new_gvf['nt_name'].str.contains("dup|del")) & ~(new_gvf['nt_name'].str.contains("delins")), 'hgvs_nt'] = new_gvf['#seqid'] + ":" + new_gvf['nt_name'].apply(remove_nts_from_nt_name)
+    new_gvf.loc[new_gvf['nt_name'].str.contains(nt_del_dup_regex, regex=True),
+                'hgvs_nt'] = new_gvf['#seqid'] + ":" + \
+                new_gvf['nt_name'].apply(remove_nts_from_nt_name)
     # add hgvs nt ins
-    new_gvf.loc[(new_gvf['nt_name'].str.startswith("g.")) & (new_gvf['nt_name'].str.contains("ins")) & ~(new_gvf['nt_name'].str.contains("delins")), 'hgvs_nt'] = new_gvf['#seqid'] + ":" + new_gvf['nt_name']  
+    new_gvf.loc[new_gvf['nt_name'].str.contains(nt_ins_regex, regex=True), 
+                'hgvs_nt'] = new_gvf['#seqid'] + ":" + new_gvf['nt_name']  
     # NOTE: nt delins mutations not covered yet, but likely 'nt_name' is 
     # already correct; holding off until I find examples in our data
+     
+    # define aa regex patterns
+    aa_snp_regex = "[A-Z*][0-9\-]+[A-Z*]"
+    aa_other_regex = "[A-Z*]+[0-9\-]+(del|delins|ins|dup|fs|ext)[A-Z*]*"
     
-    mutation_type_codes = "|".join(["del", "delins", "ins", "dup", "fs", "ext"])
-
-    # fill in 'hgvs_aa'  
-    # add hgvs aa snps to rows with protein_id!=n/a and type=snp
-    new_gvf.loc[(new_gvf['protein_id']!='n/a') & (new_gvf['#type']=='snp'), 'hgvs_aa'] = new_gvf["protein_id"] + ":" + new_gvf['aa_name'].apply(convert_amino_acid_codes)
-    # add hgvs aa names for non-snps that contain any of the mutation_type_codes
-    new_gvf.loc[(new_gvf['protein_id']!='n/a') & (new_gvf['#type']!='snp') & (new_gvf['aa_name'].str.contains(mutation_type_codes)), 'hgvs_aa'] = new_gvf["protein_id"] + ":" + new_gvf['aa_name'].apply(convert_amino_acid_codes)
+    # fill in 'hgvs_aa' 
+    # add hgvs aa snps to rows with protein_id!=n/a
+    new_gvf.loc[(new_gvf['aa_name'].str.contains(aa_snp_regex, regex=True)) &
+                (new_gvf['protein_id']!='n/a'), 'hgvs_aa'] = \
+                new_gvf["protein_id"] + ":" + new_gvf['aa_name'].apply(
+                    convert_amino_acid_codes)
+    # add hgvs aa names for non-snps
+    new_gvf.loc[(new_gvf['aa_name'].str.contains(aa_other_regex, regex=True)) &
+                (new_gvf['protein_id']!='n/a'), 'hgvs_aa'] = \
+                new_gvf["protein_id"] + ":" + new_gvf['aa_name'].apply(
+                    convert_amino_acid_codes)
 
     # fill in 'hgvs_alias'
-    # add hgvs alias names for snps
-    new_gvf.loc[(new_gvf['alias']!='n/a') & (new_gvf['protein_id']!='n/a') & (new_gvf['#type']=='snp'), 'hgvs_alias'] = new_gvf["protein_id"] + ":p." + new_gvf['alias'].apply(convert_amino_acid_codes)
-    # add hgvs alias names for non-snps that contain any of the mutation_type_codes
-    new_gvf.loc[(new_gvf['alias']!='n/a') & (new_gvf['protein_id']!='n/a') & (new_gvf['#type']!='snp') & (new_gvf['aa_name'].str.contains(mutation_type_codes)), 'hgvs_alias'] = new_gvf["protein_id"] + ":p." + new_gvf['alias'].apply(convert_amino_acid_codes)
-
+    # add hgvs alias snps to rows with protein_id!=n/a
+    new_gvf.loc[(new_gvf['alias'].str.contains(aa_snp_regex, regex=True)) &
+                (new_gvf['protein_id']!='n/a') & 
+                (new_gvf['alias']!='n/a'), 'hgvs_alias'] = \
+                new_gvf["protein_id"] + ":" + new_gvf['aa_name'].apply(
+                    convert_amino_acid_codes)
+    # add hgvs alias names for non-snps
+    new_gvf.loc[(new_gvf['alias'].str.contains(aa_other_regex, regex=True)) &
+                (new_gvf['protein_id']!='n/a') &
+                (new_gvf['alias']!='n/a'), 'hgvs_alias'] = \
+                new_gvf["protein_id"] + ":" + new_gvf['aa_name'].apply(
+                    convert_amino_acid_codes)
+                
     return(new_gvf)
 
 

--- a/bin/vcf2gvf.py
+++ b/bin/vcf2gvf.py
@@ -62,7 +62,7 @@ def vcftogvf(vcf, strain, GENE_PROTEIN_POSITIONS_DICT, sample_size):
     new_gvf = separate_attributes(new_gvf)
 
     # fill in attributes from vcf_df columns by name if they exist
-    vcf_df_cols_to_add = ['nt_name', 'aa_name', 'vcf_gene', 'mutation_type',
+    vcf_df_cols_to_add = ['vcf_gene', 'mutation_type',
                         'ps_filter', 'ps_exc', 'mat_pep','mat_pep_desc',
                         'mat_pep_acc', 'Reference_seq', 'Variant_seq',
                         "dp", "ro", "ao"]
@@ -70,6 +70,10 @@ def vcftogvf(vcf, strain, GENE_PROTEIN_POSITIONS_DICT, sample_size):
         # drop nans if they exist
         vcf_df[column] = vcf_df[column].fillna('')
         new_gvf[column] = vcf_df[column]
+    
+    for column in ['nt_name', 'aa_name']:
+        vcf_df[column] = vcf_df[column].fillna('n/a')
+        new_gvf[column] = vcf_df[column]   
 
     # add other attributes
     new_gvf['sample_size'] = sample_size
@@ -94,6 +98,9 @@ def vcftogvf(vcf, strain, GENE_PROTEIN_POSITIONS_DICT, sample_size):
     
     # add HGVS names columns: 'hgvs_nt', 'hgvs_aa', 'hgvs_alias'
     new_gvf = add_hgvs_names(new_gvf)
+    
+    # save HGVS names for troubleshooting
+    #new_gvf[['nt_name', 'hgvs_nt', 'aa_name', 'hgvs_aa', 'alias', 'hgvs_alias']].to_csv('hgvs_troubleshooting.tsv', sep='\t')
     
     # add 'ID' attribute: here, rows with the same entry in 'Name'
     # get the same ID (should all be different)


### PR DESCRIPTION
Issue was with incorrect use of `apply()`.

Code should run as is (unless `fillna("n/a")` for `nt_name` and `aa_name` has broken something downstream I haven't anticipated). Delins nt-level names still need to be parsed into HGVS (I'll work on this after Oc/Or tomorrow); these and any other unrecognized names will be called "n/a" in the GVF for now.

The HGVS name translations for `HV.1.6.annotated.vcf` are captured in [this Google Sheet](https://docs.google.com/spreadsheets/d/1Keb8E6lDQA3pcZisDztZ8XzC6NqoDchNfn2-28pA-24/edit?usp=sharing), to be reviewed again in the morning.