### PR TITLE
Add compatibility for SnpEFF >=5.0 with "ANN"

### DIFF
--- a/assets/virus_geneCoordinates/NC_007362.1/NC_007362.1._ontology.json
+++ b/assets/virus_geneCoordinates/NC_007362.1/NC_007362.1._ontology.json
@@ -36,7 +36,7 @@
             "uri": "GENEPIO:0102001"
         },
         "strand_orientation": {
-            "label": "negative strand orientation",
+            "label": "antisense strand orientation",
             "uri": "GENEPIO:0700003"
         },
         "gene_orientation": {

--- a/bin/functions.py
+++ b/bin/functions.py
@@ -376,8 +376,7 @@ def parse_INFO(df, var_cols): # return INFO dataframe with named columns, includ
     # expand "unknown" column into multiple named columns
     unknown = df['unknown'].str.split(pat=':').apply(pd.Series)
     unknown.columns = var_cols
-    print("var_cols:")
-    print(var_cols)
+
     # drop columns in df that have the same name as 'unknown' column names
     cols_to_drop = list(set(df.columns) & set(unknown.columns)) 
     df = df.drop(columns=cols_to_drop)

--- a/bin/functions.py
+++ b/bin/functions.py
@@ -125,9 +125,15 @@ def add_hgvs_names(new_gvf):
     new_gvf['hgvs_nt'] = new_gvf['#seqid'] + "(" + new_gvf['locus_tag'] + "):" + new_gvf['nt_name']
 
     # revert nt_name to old format
+    # snps
     nt_snp_mask = new_gvf['hgvs_nt'].str.contains(">", regex=False)
     new_gvf.loc[nt_snp_mask, 'nt_name'] = new_gvf.loc[nt_snp_mask, 'nt_name'].apply(undo_hgvs_snps)
     
+    # revert hgvs_nt to old format
+    # dels
+    nt_del_mask = (new_gvf['hgvs_nt'].str.contains("del", regex=False) & ~new_gvf['hgvs_nt'].str.contains("delins", regex=False))
+    new_gvf.loc[nt_del_mask, 'hgvs_nt'] = new_gvf.loc[nt_del_mask, 'hgvs_nt'].apply(remove_nts_from_nt_name)
+
     # remove transcript id in parentheses for all HGVS nucleotide names where 'locus_tag'=='n/a'
     new_gvf['hgvs_nt'] = new_gvf['hgvs_nt'].str.replace("(n/a)", "", regex=False)
 

--- a/bin/functions.py
+++ b/bin/functions.py
@@ -517,11 +517,21 @@ def map_pos_to_gene_protein(pos, GENE_PROTEIN_POSITIONS_DICT):
             gene = GENE_PROTEIN_POSITIONS_DICT[entry]["gene"]
             product = GENE_PROTEIN_POSITIONS_DICT[entry]["product"]
             protein_alias = GENE_PROTEIN_POSITIONS_DICT[entry]["protein_alias"]
-            protein_name = GENE_PROTEIN_POSITIONS_DICT[entry]["protein_name"]["label"] + ' [' + GENE_PROTEIN_POSITIONS_DICT[entry]["protein_name"]["uri"] + ']'
-            protein_symbol = GENE_PROTEIN_POSITIONS_DICT[entry]["protein_symbol"]["label"] + ' [' + GENE_PROTEIN_POSITIONS_DICT[entry]["protein_symbol"]["uri"] + ']'
             protein_id = GENE_PROTEIN_POSITIONS_DICT[entry]["protein_id"]
             locus_tag = GENE_PROTEIN_POSITIONS_DICT[entry]["locus_tag"]
-    
+
+            # add ontology terms if the JSON file contains them
+
+            if "protein_name" in GENE_PROTEIN_POSITIONS_DICT[entry].keys():
+                protein_name = GENE_PROTEIN_POSITIONS_DICT[entry]["protein_name"]["label"] + ' [' + GENE_PROTEIN_POSITIONS_DICT[entry]["protein_name"]["uri"] + ']'
+            else:
+                protein_name = 'n/a'
+
+            if "protein_symbol" in GENE_PROTEIN_POSITIONS_DICT[entry].keys():
+                protein_symbol = GENE_PROTEIN_POSITIONS_DICT[entry]["protein_symbol"]["label"] + ' [' + GENE_PROTEIN_POSITIONS_DICT[entry]["protein_symbol"]["uri"] + ']'
+            else:
+                protein_symbol = 'n/a'
+
             # fill in attributes for mutations in this CDS region
             cds_mask = df[pos_column].astype(int).between(start, end, inclusive="both")
             df.loc[cds_mask, "gene"] = gene
@@ -537,11 +547,29 @@ def map_pos_to_gene_protein(pos, GENE_PROTEIN_POSITIONS_DICT):
             # extract values from JSON entry
             start = GENE_PROTEIN_POSITIONS_DICT[entry]["start"]
             end = GENE_PROTEIN_POSITIONS_DICT[entry]["end"]
-            gene_name = GENE_PROTEIN_POSITIONS_DICT[entry]["gene_name"]["label"] + ' [' + GENE_PROTEIN_POSITIONS_DICT[entry]["gene_name"]["uri"] + ']'
-            gene_symbol = GENE_PROTEIN_POSITIONS_DICT[entry]["gene_symbol"]["label"] + ' [' + GENE_PROTEIN_POSITIONS_DICT[entry]["gene_symbol"]["uri"] + ']'
-            strand_orientation = GENE_PROTEIN_POSITIONS_DICT[entry]["strand_orientation"]["label"] + ' [' + GENE_PROTEIN_POSITIONS_DICT[entry]["strand_orientation"]["uri"] + ']'
-            gene_orientation = GENE_PROTEIN_POSITIONS_DICT[entry]["gene_orientation"]["label"] + ' [' + GENE_PROTEIN_POSITIONS_DICT[entry]["gene_orientation"]["uri"] + ']'
-            
+
+            # add ontology terms if the JSON file contains them
+
+            if "gene_name" in GENE_PROTEIN_POSITIONS_DICT[entry].keys():
+                gene_name = GENE_PROTEIN_POSITIONS_DICT[entry]["gene_name"]["label"] + ' [' + GENE_PROTEIN_POSITIONS_DICT[entry]["gene_name"]["uri"] + ']'
+            else:
+                gene_name = 'n/a'
+
+            if "gene_symbol" in GENE_PROTEIN_POSITIONS_DICT[entry].keys():
+                gene_symbol = GENE_PROTEIN_POSITIONS_DICT[entry]["gene_symbol"]["label"] + ' [' + GENE_PROTEIN_POSITIONS_DICT[entry]["gene_symbol"]["uri"] + ']'
+            else:
+                gene_symbol = 'n/a'
+
+            if "strand_orientation" in GENE_PROTEIN_POSITIONS_DICT[entry].keys():
+                strand_orientation = GENE_PROTEIN_POSITIONS_DICT[entry]["strand_orientation"]["label"] + ' [' + GENE_PROTEIN_POSITIONS_DICT[entry]["strand_orientation"]["uri"] + ']'
+            else:
+                strand_orientation = 'n/a'
+
+            if "gene_orientation" in GENE_PROTEIN_POSITIONS_DICT[entry].keys():
+                gene_orientation = GENE_PROTEIN_POSITIONS_DICT[entry]["gene_orientation"]["label"] + ' [' + GENE_PROTEIN_POSITIONS_DICT[entry]["gene_orientation"]["uri"] + ']'
+            else:
+                gene_orientation = 'n/a'            
+
             # fill in attributes for mutations in this gene region
             gene_mask = df[pos_column].astype(int).between(start, end, inclusive="both")
             df.loc[gene_mask, "gene_name"] = gene_name

--- a/bin/functions.py
+++ b/bin/functions.py
@@ -517,8 +517,8 @@ def map_pos_to_gene_protein(pos, GENE_PROTEIN_POSITIONS_DICT):
             gene = GENE_PROTEIN_POSITIONS_DICT[entry]["gene"]
             product = GENE_PROTEIN_POSITIONS_DICT[entry]["product"]
             protein_alias = GENE_PROTEIN_POSITIONS_DICT[entry]["protein_alias"]
-            protein_name = GENE_PROTEIN_POSITIONS_DICT[entry]["protein_name"]["label"]
-            protein_symbol = GENE_PROTEIN_POSITIONS_DICT[entry]["protein_symbol"]["label"]
+            protein_name = GENE_PROTEIN_POSITIONS_DICT[entry]["protein_name"]["label"] + ' [' + GENE_PROTEIN_POSITIONS_DICT[entry]["protein_name"]["uri"] + ']'
+            protein_symbol = GENE_PROTEIN_POSITIONS_DICT[entry]["protein_symbol"]["label"] + ' [' + GENE_PROTEIN_POSITIONS_DICT[entry]["protein_symbol"]["uri"] + ']'
             protein_id = GENE_PROTEIN_POSITIONS_DICT[entry]["protein_id"]
             locus_tag = GENE_PROTEIN_POSITIONS_DICT[entry]["locus_tag"]
     
@@ -537,10 +537,10 @@ def map_pos_to_gene_protein(pos, GENE_PROTEIN_POSITIONS_DICT):
             # extract values from JSON entry
             start = GENE_PROTEIN_POSITIONS_DICT[entry]["start"]
             end = GENE_PROTEIN_POSITIONS_DICT[entry]["end"]
-            gene_name = GENE_PROTEIN_POSITIONS_DICT[entry]["gene_name"]["label"]
-            gene_symbol = GENE_PROTEIN_POSITIONS_DICT[entry]["gene_symbol"]["label"]
-            strand_orientation = GENE_PROTEIN_POSITIONS_DICT[entry]["strand_orientation"]["label"]
-            gene_orientation = GENE_PROTEIN_POSITIONS_DICT[entry]["gene_orientation"]["label"]
+            gene_name = GENE_PROTEIN_POSITIONS_DICT[entry]["gene_name"]["label"] + ' [' + GENE_PROTEIN_POSITIONS_DICT[entry]["gene_name"]["uri"] + ']'
+            gene_symbol = GENE_PROTEIN_POSITIONS_DICT[entry]["gene_symbol"]["label"] + ' [' + GENE_PROTEIN_POSITIONS_DICT[entry]["gene_symbol"]["uri"] + ']'
+            strand_orientation = GENE_PROTEIN_POSITIONS_DICT[entry]["strand_orientation"]["label"] + ' [' + GENE_PROTEIN_POSITIONS_DICT[entry]["strand_orientation"]["uri"] + ']'
+            gene_orientation = GENE_PROTEIN_POSITIONS_DICT[entry]["gene_orientation"]["label"] + ' [' + GENE_PROTEIN_POSITIONS_DICT[entry]["gene_orientation"]["uri"] + ']'
             
             # fill in attributes for mutations in this gene region
             gene_mask = df[pos_column].astype(int).between(start, end, inclusive="both")
@@ -553,6 +553,8 @@ def map_pos_to_gene_protein(pos, GENE_PROTEIN_POSITIONS_DICT):
     df.loc[df["gene"].isna(), "gene"] = "intergenic"
     # label all mutations that didn't belong to any protein as "n/a"
     df = df.fillna("n/a")
+    # to account for missing ontology terms, replace " []" with "n/a"
+    df = df.replace(" []", "n/a")
 
     return(df)
 

--- a/bin/functions.py
+++ b/bin/functions.py
@@ -191,7 +191,7 @@ def get_unknown_labels(df):
         # use "RO" instead of "REF_DP" to match GVF standard
         # use "AO" instead of "ALT_DP" to match GVF standard
         columns = [x.lower() for x in ["GT","RO","REF_RV","REF_QUAL","AO","ALT_RV","ALT_QUAL","ALT_FREQ"]]
-        
+ 
     return columns
         
 
@@ -297,27 +297,27 @@ def unnest_multi(df, columns, reset_index=False):
     return df
 
 
-def select_snpeff_records(eff_string, ao_count):
+def select_snpeff_records(ann_string, ao_count):
     
-    eff_list = eff_string.split(",")
+    ann_list = ann_string.split(",")
 
     # if any records in the row contain '|p.', take only those records
-    EFF_records_list = [s for s in eff_list if '|p.' or 'LOF' in s]
+    ANN_records_list = [s for s in ann_list if '|p.' or 'LOF' in s]
 
     # if no records contain '|p.', take the "intergenic" record
-    if len(EFF_records_list) == 0:
-        EFF_records_list = [s for s in eff_list if 'intergenic_region' in s]
+    if len(ANN_records_list) == 0:
+        ANN_records_list = [s for s in ann_list if 'intergenic_region' in s]
 
     # filter out annotations that include 'WARNING' or 'GU280_gp01.2'
     # this keeps 'GU280_gp01' annotations over 'GU280_gp01.2'
-    EFF_records_list = [s for s in EFF_records_list if 'WARNING' not in s
+    ANN_records_list = [s for s in ANN_records_list if 'WARNING' not in s
                         and 'GU280_gp01.2' not in s]
     
     # of the filtered records, take only the first N, where N is the number
     # of comma-separated AO values given in the "unknown" column
-    EFF_records_list = EFF_records_list[:ao_count]
+    ANN_records_list = ANN_records_list[:ao_count]
     
-    return EFF_records_list
+    return ANN_records_list
 
 
 def find_sample_size(table, lineage, vcf_file, wastewater):
@@ -355,16 +355,16 @@ def find_sample_size(table, lineage, vcf_file, wastewater):
 
 
     
-def parse_INFO(df, var_cols): # return INFO dataframe with named columns, including EFF split apart
+def parse_INFO(df, var_cols): # return INFO dataframe with named columns, including ANN split apart
 
     # extract these key-value pairs in INFO into their own columns
-    cols_to_extract = ['DP', 'ps_filter', 'ps_exc', 'EFF', 'mat_pep', 'mat_pep_desc', 'mat_pep_acc']
+    cols_to_extract = ['DP', 'ps_filter', 'ps_exc', 'ANN', 'mat_pep', 'mat_pep_desc', 'mat_pep_acc']
     info = pd.DataFrame(columns=cols_to_extract)
     for col in cols_to_extract:
         pat = str(col) + "\=(.*?)(?=[\;]|$)" 
         info[col] = df['INFO'].str.extract(pat)
     # rename uppercase columns as lowercase
-    info = info.rename(columns={'DP':'dp', 'EFF':'eff'})
+    info = info.rename(columns={'DP':'dp', 'ANN':'ann'})
 
     # concatenate info and df horizontally
     df = pd.concat([df, info], axis=1)
@@ -373,11 +373,14 @@ def parse_INFO(df, var_cols): # return INFO dataframe with named columns, includ
     # expand "unknown" column into multiple named columns
     unknown = df['unknown'].str.split(pat=':').apply(pd.Series)
     unknown.columns = var_cols
-    #drop columns in df that have the same name as 'unknown' column names
+    print("var_cols:")
+    print(var_cols)
+    # drop columns in df that have the same name as 'unknown' column names
     cols_to_drop = list(set(df.columns) & set(unknown.columns)) 
     df = df.drop(columns=cols_to_drop)
-
+    # concatenate 'unknown' columns to df
     df = pd.concat([df, unknown], axis=1)
+
     # make ALT, AO, type into lists
     for column in ["ao", "ALT"]:
         df[column] = df[column].str.split(",")
@@ -385,10 +388,12 @@ def parse_INFO(df, var_cols): # return INFO dataframe with named columns, includ
         df["type"] = df["type"].str.split(",")   
     # get number of AO values given in "unknown" column
     df['ao_count'] = df["ao"].str.len()
+
+    # parse ANN entry from INFO
+    df["ann_result"] = [select_snpeff_records(x, y) for x, y in
+                        zip(df['ann'], df["ao_count"])]
     
-    # parse EFF entry from INFO
-    df["eff_result"] = [select_snpeff_records(x, y) for x, y in
-                        zip(df['eff'], df["ao_count"])]
+ 
     #df.to_csv("eff_result_checking.tsv", sep="\t")
     # check how many "type" entries there are
     #df['eff_result_len'] = df["eff_result"].str.len()
@@ -398,57 +403,50 @@ def parse_INFO(df, var_cols): # return INFO dataframe with named columns, includ
     #mismatch.to_csv("mismatches.csv", sep='\t', header=True, index=True)
     # unnest list columns
     if "type" in df.columns: # "type" is not an attribute of INFO for wastewater
-        df = unnest_multi(df, ["eff_result", "ao", "ALT", "type"], reset_index=True)
+        df = unnest_multi(df, ["ann_result", "ao", "ALT", "type"], reset_index=True)
     else:
-        df = unnest_multi(df, ["eff_result", "ao", "ALT"], reset_index=True)
+        df = unnest_multi(df, ["ann_result", "ao", "ALT"], reset_index=True)
     # calculate Alternate Frequency
     df['AF'] = df['ao'].astype(int) / df['dp'].astype(int)
 
-    # expand the contents of eff_result into separate columns, named as in the 
+    # expand the contents of ann_result into separate columns, named as in the 
     # VCF header
-    eff_info = df['eff_result'].str.findall('\\((.*?)\\)').str[0]
     # split at pipe, form dataframe
-    eff_info = eff_info.str.split(pat='|').apply(pd.Series)
-    num_cols = len(eff_info.columns)
-    eff_info_cols = ['Effect_Impact','Functional_Class','Codon_Change','Amino_Acid_Change','Amino_Acid_length','Gene_Name','Transcript_BioType','Gene_Coding','Transcript_ID','Exon_Rank','Genotype ERRORS', 'Genotype WARNINGS'][:num_cols]
-    eff_info.columns = eff_info_cols
+    ann_info = df['ann_result'].str.split(pat='|').apply(pd.Series)
+    num_cols = len(ann_info.columns)
+    # ann_info_cols are hardcoded from the pragma beginning with '##INFO=<ID=ANN' for SnpEffVersion=5.0e
+    #eff_info_cols = ['Effect_Impact','Functional_Class','Codon_Change','Amino_Acid_Change','Amino_Acid_length','Gene_Name','Transcript_BioType','Gene_Coding','Transcript_ID','Exon_Rank','Genotype ERRORS', 'Genotype WARNINGS'][:num_cols]
+    ann_info_cols = ['Allele', 'Annotation', 'Annotation_Impact', 'Gene_Name', 'Gene_ID', 'Feature_Type', 'Feature_ID', 'Transcript_BioType', 'Rank', 'HGVS.c', 'HGVS.p', 'cDNA.pos / cDNA.length', 'CDS.pos / CDS.length', 'AA.pos / AA.length', 'Distance', 'ERRORS / WARNINGS / INFO']
+    ann_info.columns = ann_info_cols
+    # add split ANN columns to df
+    df = pd.concat([df, ann_info], axis=1)
+    df = df.drop(columns='ann_result')
 
-    df = pd.concat([df, eff_info], axis=1)
-    df = df.drop(columns='eff_result')
-    
+    df = df.rename(columns={'HGVS.c': 'nt_name', 'HGVS.p': 'aa_name'})
 
-    # split df['Amino_Acid_Change'] into two columns: one for HGVS amino acid
-    # names, and the righthand column for nucleotide-level names
-    name_mask = df['Amino_Acid_Change'].str.contains('/')
-    df.loc[~name_mask, 'Amino_Acid_Change'] = '/' + df['Amino_Acid_Change']
-    hgvs = df['Amino_Acid_Change'].str.rsplit(pat='/').apply(pd.Series)
-    hgvs.columns = ["hgvs_protein", "hgvs_nucleotide"]
-    df = pd.concat([df, hgvs], axis=1)
-    
     # make adjustments to the nucleotide names
     # 1) change 'c.' to 'g.'convert_amino_acid_codes for nucleotide names ### double check that we want this
-    df["hgvs_nucleotide"] = df["hgvs_nucleotide"].str.replace("c.", "g.", regex=False) 
-    df["hgvs_nucleotide"] = df["hgvs_nucleotide"].str.replace("n.", "g.", regex=False) 
+    df["nt_name"] = df["nt_name"].str.replace("c.", "g.", regex=False) 
+    df["nt_name"] = df["nt_name"].str.replace("n.", "g.", regex=False) 
     # 2) change nucleotide names of the form "g.C*4378A" to g.C4378AN;
-    asterisk_mask = df["hgvs_nucleotide"].str.contains('*', regex=False)
-    df.loc[asterisk_mask, "hgvs_nucleotide"] = 'g.' + df['REF'] + df['POS'] + \
+    asterisk_mask = df["nt_name"].str.contains('*', regex=False)
+    df.loc[asterisk_mask, "nt_name"] = 'g.' + df['REF'] + df['POS'] + \
         df['ALT']
     # 3) change 'Gene_Name' to "intergenic" where names contain a "*"
     df.loc[asterisk_mask, 'Gene_Name'] = "intergenic"
 
     # create a "Names" column that holds the amino acid name (minus 'p.')
     # if there is one, or the nucleotide level name if not
-    df["Names"] = df["hgvs_nucleotide"]
-    protein_mask = df["hgvs_protein"].str.contains("p.")
-    df.loc[protein_mask, "Names"] = df["hgvs_protein"].str.replace(
+    df["Names"] = df["nt_name"]
+    protein_mask = df["aa_name"].str.contains("p.")
+    df.loc[protein_mask, "Names"] = df["aa_name"].str.replace(
         "p.", "", regex=False)
 
     # rename some columns
-    df = df.rename(columns={'Gene_Name': "vcf_gene", 'Functional_Class':
-                            "mutation_type", 'hgvs_nucleotide': 'nt_name',
-                            'hgvs_protein': 'aa_name', 'REF': 'Reference_seq',
+    df = df.rename(columns={'Gene_Name': "vcf_gene", 'Annotation':
+                            "mutation_type", 'REF': 'Reference_seq',
                             'ALT': 'Variant_seq'})
-
+    
     return(df)
     
 

--- a/bin/functions.py
+++ b/bin/functions.py
@@ -52,6 +52,15 @@ def rewrite_nt_snps_as_hgvs(original_nt_name):
 
     return(hgvs_name)
 
+def undo_hgvs_snps(hgvs_nt_name):
+    # interim function for updated SnpEFF
+    # converts eg. g.33C>T to g.C33T
+    pos = "".join([i for i in hgvs_nt_name if i.isdigit()])
+    nts_list = [ch for ch in hgvs_nt_name if ch.isupper()]
+    non_hgvs_name = "g." + nts_list[0] + pos + nts_list[1] ##may change "g." in future
+
+    return(non_hgvs_name)
+
 def remove_nts_from_nt_name(original_nt_name):
     # sufficient for nt names containing "del" or "dup"
     # will not work for "ins" or "delins"
@@ -78,33 +87,47 @@ def add_hgvs_names(new_gvf):
 
     """    
     # define nt regex patterns
+
     # for SNPs, eg. g.C45T, g.C-45T
     nt_snp_regex = "[a-z]\\.[A-Z][0-9\\-]+[A-Z]"
+
     # for dels and dups, eg. g.254_259delTGGTTG, g.361delA
     nt_del_dup_regex = "[a-z]\\.[0-9\\-_]+(?:del|dup)[A-Z]+"
+
     # for ins
     nt_ins_regex = "[a-z]\\.[0-9\\-_]+ins[A-Z]+"
+
     # for delins, eg. g.GCC10182_10184ACA
     nt_delins_regex = "[a-z]\.[A-Z]+-?[0-9]+_-?[0-9]+[A-Z]+" 
     
     #df.loc[mask, 'val'] = df.loc[mask, 'val'].apply(f)
+
     # add hgvs nt snp names
+    # find the rows where nt_name is a snp matching nt_snp_regex
     nt_snp_mask = new_gvf['nt_name'].str.contains(nt_snp_regex, regex=True)
+    # write hgvs_nt in HGVS format
     new_gvf.loc[nt_snp_mask, 'hgvs_nt'] = new_gvf['#seqid'] + "(" + new_gvf['locus_tag'] + "):" + \
                  new_gvf.loc[nt_snp_mask, 'nt_name'].apply(rewrite_nt_snps_as_hgvs)
+    
     # add hgvs nt dels and dups
     nt_del_dup_mask = new_gvf['nt_name'].str.contains(nt_del_dup_regex, regex=True)
     new_gvf.loc[nt_del_dup_mask,'hgvs_nt'] = new_gvf['#seqid'] + "(" + new_gvf['locus_tag'] + "):" + \
                 new_gvf.loc[nt_del_dup_mask, 'nt_name'].apply(remove_nts_from_nt_name)
+    
     # add hgvs nt ins
     nt_ins_mask = new_gvf['nt_name'].str.contains(nt_ins_regex, regex=True)
     new_gvf.loc[nt_ins_mask, 'hgvs_nt'] = new_gvf['#seqid'] + "(" + new_gvf['locus_tag'] + "):" + new_gvf['nt_name']  
+    
     # add hgvs nt delins: change to eg. g.123_129delinsAC
     nt_delins_mask = new_gvf['nt_name'].str.contains(nt_delins_regex, regex=True)
     #new_gvf.loc[nt_delins_mask, 'hgvs_nt'] = new_gvf['#seqid'] + "(" + new_gvf['locus_tag'] + "):" + "TBA!" #new_gvf['nt_name']  
     """    
     new_gvf['hgvs_nt'] = new_gvf['#seqid'] + "(" + new_gvf['locus_tag'] + "):" + new_gvf['nt_name']
 
+    # revert nt_name to old format
+    nt_snp_mask = new_gvf['hgvs_nt'].str.contains(">", regex=False)
+    new_gvf.loc[nt_snp_mask, 'nt_name'] = new_gvf.loc[nt_snp_mask, 'nt_name'].apply(undo_hgvs_snps)
+    
     # remove transcript id in parentheses for all HGVS nucleotide names where 'locus_tag'=='n/a'
     new_gvf['hgvs_nt'] = new_gvf['hgvs_nt'].str.replace("(n/a)", "", regex=False)
 

--- a/bin/functions.py
+++ b/bin/functions.py
@@ -602,11 +602,10 @@ def clade_defining_threshold(threshold, df, sample_size):
 
 
 def add_alias_names(df, GENE_PROTEIN_POSITIONS_DICT):
-    '''Creates alias names for Orf1ab mutations, reindexing the amino acid numbers.'''
+    '''Creates alias names for mature peptide mutations (eg. Orf1ab mutations), reindexing the amino acid numbers.'''
     df.loc[:, 'alias'] = 'n/a'
 
-    # get list of all NSP, 3CL, and PlPro proteins in the file:
-    #alias_mask = (df['gene_symbol'].str.contains("orf1ab")) & (df['mat_pep']!='n/a')
+    # get list of all mature peptide proteins in the file (eg. NSPs, 3CL, and PlPro):
     alias_mask = (df['mat_pep']!='n/a')
     nsps_list = sorted(list(set(df[alias_mask]['mat_pep'].tolist())))
     if len(nsps_list) > 0:
@@ -634,6 +633,7 @@ def add_alias_names(df, GENE_PROTEIN_POSITIONS_DICT):
         
         # for each nsp in nsps_list, operate on the number column based on the nsp start coordinates
         for nsp in nsps_list:
+            # hardcoding PL_pro for SARS-COV-2
             if nsp=='PL_proPLpro':
                 nsp='PL_pro'
             nsp_start_aa = int(GENE_PROTEIN_POSITIONS_DICT[nsp]["aa_start"])

--- a/bin/functions.py
+++ b/bin/functions.py
@@ -75,7 +75,8 @@ def add_hgvs_names(new_gvf):
     new_gvf['hgvs_alias'] = 'n/a'
     
     # fill in 'hgvs_nt'
-    
+
+    """    
     # define nt regex patterns
     # for SNPs, eg. g.C45T, g.C-45T
     nt_snp_regex = "[a-z]\\.[A-Z][0-9\\-]+[A-Z]"
@@ -101,6 +102,8 @@ def add_hgvs_names(new_gvf):
     # add hgvs nt delins: change to eg. g.123_129delinsAC
     nt_delins_mask = new_gvf['nt_name'].str.contains(nt_delins_regex, regex=True)
     #new_gvf.loc[nt_delins_mask, 'hgvs_nt'] = new_gvf['#seqid'] + "(" + new_gvf['locus_tag'] + "):" + "TBA!" #new_gvf['nt_name']  
+    """    
+    new_gvf['hgvs_nt'] = new_gvf['#seqid'] + "(" + new_gvf['locus_tag'] + "):" + new_gvf['nt_name']
 
     # remove transcript id in parentheses for all HGVS nucleotide names where 'locus_tag'=='n/a'
     new_gvf['hgvs_nt'] = new_gvf['hgvs_nt'].str.replace("(n/a)", "", regex=False)

--- a/bin/functions.py
+++ b/bin/functions.py
@@ -133,6 +133,9 @@ def add_hgvs_names(new_gvf):
     # dels
     nt_del_mask = (new_gvf['hgvs_nt'].str.contains("del", regex=False) & ~new_gvf['hgvs_nt'].str.contains("delins", regex=False))
     new_gvf.loc[nt_del_mask, 'hgvs_nt'] = new_gvf.loc[nt_del_mask, 'hgvs_nt'].apply(remove_nts_from_nt_name)
+    # dups
+    nt_dup_mask = new_gvf['hgvs_nt'].str.contains("dup", regex=False)
+    new_gvf.loc[nt_dup_mask, 'hgvs_nt'] = new_gvf.loc[nt_dup_mask, 'hgvs_nt'].apply(remove_nts_from_nt_name)
 
     # remove transcript id in parentheses for all HGVS nucleotide names where 'locus_tag'=='n/a'
     new_gvf['hgvs_nt'] = new_gvf['hgvs_nt'].str.replace("(n/a)", "", regex=False)

--- a/bin/functions.py
+++ b/bin/functions.py
@@ -606,7 +606,8 @@ def add_alias_names(df, GENE_PROTEIN_POSITIONS_DICT):
     df.loc[:, 'alias'] = 'n/a'
 
     # get list of all NSP, 3CL, and PlPro proteins in the file:
-    alias_mask = (df['gene_symbol'].str.contains("orf1ab")) & (df['mat_pep']!='n/a')
+    #alias_mask = (df['gene_symbol'].str.contains("orf1ab")) & (df['mat_pep']!='n/a')
+    alias_mask = (df['mat_pep']!='n/a')
     nsps_list = sorted(list(set(df[alias_mask]['mat_pep'].tolist())))
     if len(nsps_list) > 0:
         

--- a/bin/vcf2gvf.py
+++ b/bin/vcf2gvf.py
@@ -178,8 +178,10 @@ if __name__ == '__main__':
     
 
     # print("Processing: " + vcf_file)
-
-    sample_size = find_sample_size(size_stats, strain, vcf_file, args.wastewater)
+    if size_stats=='n/a':
+        sample_size = 'n/a'
+    else:
+        sample_size = find_sample_size(size_stats, strain, vcf_file, args.wastewater)
     
     # create gvf from annotated vcf (ignoring pragmas for now)
     gvf = vcftogvf(vcf_file, strain, GENE_PROTEIN_POSITIONS_DICT,


### PR DESCRIPTION
This pull request fulfils https://github.com/cidgoh/nf-ncov-voc/issues/203.

**Notes:**

- I wasn't able to replicate the bug that produced "H,A" in protein_alias.
- Ontology URIs are now included in the GVF in square brackets
- Ontology terms are now optional

**To discuss tomorrow:**

This now runs as expected for `sampleA.H5N1.HA.vcf` (iVar) and `SampleB-Rpt__NC_007362.1__h5n1__HA__anno.vcf` (FreeBayes), with two exceptions detailed in issues:
1. `nt_name` is now formatted differently than before (https://github.com/cidgoh/nf-ncov-voc/issues/211)
2. `mutation_type` in the GVF now draws from 'Annotation' in ANN rather than 'Functional Class' in EFF, and looks slightly different (https://github.com/cidgoh/nf-ncov-voc/issues/210)
3. We're still getting some weird amino acid names from SnpEFF. This is an old issue and not related to the new version of SnpEFF. https://github.com/cidgoh/nf-ncov-voc/issues/150